### PR TITLE
feat : Add default language

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,21 @@ SomeCoroutineScope.launch {
 }
 ```
 
+If you need a fallback language, like english if `Gero` can't find the translation in the other files,
+you can specify it using the `fallbackLocale: Locale` argument.
+
+By default, this parameter is set to `Locale.US`, if you want, for example, German, use it this way
+
+```kotlin
+SomeCoroutineScope.launch {
+    Gero.setLocaleAsync(
+        baseContext,
+        Locale.FRANCE,
+        fallbackLocale = Locale.GERMANY
+    ).await()
+}
+```
+
 This method will do 2 things:
 
 1. Check all the files under the assets subfolder and register which file goes for which language

--- a/gero/proguard-rules.pro
+++ b/gero/proguard-rules.pro
@@ -1,1 +1,7 @@
 -keep class org.mozilla.** { *; }
+-assumenosideeffects class android.util.Log {
+    public static boolean isLoggable(java.lang.String, int);
+    public static int v(...);
+    public static int d(...);
+    public static int i(...);
+}


### PR DESCRIPTION
`fun setLocaleAsync(context: Context, locale: Locale)` moves to `fun setLocaleAsync(context: Context, locale: Locale, fallbackLocale: Locale = Locale.US`)
The fallback locale is used if the key asked in `getString` or `getQuantityString` is not found in the current locale files