### PR TITLE
feat: Add getCurrentLocale getter

### DIFF
--- a/gero/src/main/java/com/github/quentin7b/android/gero/Gero.kt
+++ b/gero/src/main/java/com/github/quentin7b/android/gero/Gero.kt
@@ -262,6 +262,15 @@ class Gero private constructor(
                 throw Resources.NotFoundException("Cant find string with key $key in current files")
             }
         }
+
+        /**
+         * Returns the current locale of the Gero instance
+         * @return the current Locale
+         * @see Locale
+         */
+        fun getCurrentLocale(): Locale {
+            return get().currentLocale
+        }
     }
 }
 


### PR DESCRIPTION
Add a `getCurrentLocale` function to give back the current Locale set in `Gero`